### PR TITLE
Linker fails when 13+ batteries are configured on Xtensa ESP32

### DIFF
--- a/components/pytes_e_box/__init__.py
+++ b/components/pytes_e_box/__init__.py
@@ -2,6 +2,7 @@ import logging
 import esphome.codegen as cg
 from esphome.components import uart
 import esphome.config_validation as cv
+from esphome.core import CORE
 from esphome.const import (
     CONF_ID,
     CONF_NAME,
@@ -119,5 +120,22 @@ async def to_code(config):
     cg.add(var.set_system_battery_count(config[CONF_BATTERIES_COMPONENT]))
     cg.add(var.set_polling_timeout(config[CONF_POLL_TIMEOUT]))
     cg.add(var.set_cmd_idle_time(config[CONF_CMD_IDLE_TIME]))
+
+    # Xtensa l32r has ~256 KB reach; with many batteries the consolidated
+    # .literal section drifts past it. Inlining literals into .text gives
+    # each function its own reachable literal pool. Skipped on RISC-V
+    # variants (ESP32-C3/C6/H2 etc.) where the flag is unknown to GCC.
+    if CORE.is_esp8266:
+        cg.add_build_flag("-mtext-section-literals")
+    elif CORE.is_esp32:
+        from esphome.components.esp32 import get_esp32_variant
+        from esphome.components.esp32.const import (
+            VARIANT_ESP32,
+            VARIANT_ESP32S2,
+            VARIANT_ESP32S3,
+        )
+        if get_esp32_variant() in (VARIANT_ESP32, VARIANT_ESP32S2, VARIANT_ESP32S3):
+            cg.add_build_flag("-mtext-section-literals")
+
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)


### PR DESCRIPTION
## Problem
Linker fails when 13+ batteries are configured on Xtensa ESP32:
Each battery emits ~33 setter calls in setup() and each cell emits
~11 more, so 15 batteries × 16 cells produces ~3000 statements in
one function. The default consolidated `.literal` section drifts
past `l32r`'s ~256 KB PC-relative reach (the `0x3fefb` offset in
the error is exactly that boundary).

## Fix
Add `-mtext-section-literals` via `cg.add_build_flag(...)` in the
component's `to_code()`. The Xtensa assembler then emits per-function
literal pools inline in `.text`, keeping every load in range.
